### PR TITLE
Feat/per signal exporter selection

### DIFF
--- a/OTLP-GitHubAction-Exporter.yaml.coralogix.example
+++ b/OTLP-GitHubAction-Exporter.yaml.coralogix.example
@@ -18,6 +18,10 @@ env:
   # Change to your region's endpoint (https://coralogix.com/docs/integrations/coralogix-endpoints/)
   OTEL_EXPORTER_OTLP_ENDPOINT: https://ingress.eu2.coralogix.com/ 
   OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer ${{ secrets.CORALOGIX_API_KEY }}
+  # Per-signal selection (OpenTelemetry standard vars). Set to "none" to disable a signal
+  # OTEL_TRACES_EXPORTER: none
+  # OTEL_METRICS_EXPORTER: none
+  # OTEL_LOGS_EXPORTER: none
   GITHUB_CUSTOM_ATTS: '{"cx.application.name":"github", "cx.subsystem.name":"actions"}'
   # You can override service.name or make subsystem dynamic
   # GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":${{ github.repository }}}'

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ This means it will run whenever any of your other workflows complete - which mea
 
 `GITHUB_DEBUG` - see [Troubleshooting](#Troubleshooting)
 
+`OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` - Per-signal on/off switches following the [OpenTelemetry SDK exporter spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/). A signal is **disabled** only when its variable is set to `none` (case-insensitive). Any other value — unset, empty, `otlp`, etc. — leaves the signal **enabled**. By default all three are unset, so all signals are exported (unchanged behavior). When a signal is disabled, no exporter is created and no data is sent for it. Note: only `none` is special-cased to disable; any other value is treated as OTLP (other exporter types such as `console` are not supported).
+
+#### Example: traces only
+
+To export spans but no metrics or logs:
+
+\```yaml
+env:
+  OTEL_METRICS_EXPORTER: none
+  OTEL_LOGS_EXPORTER: none
+\```
+
 ## Examples
 
 Traces are viewable in the Tracing console within Coralogix. The service name will be your repository name:

--- a/src/custom_parser/__init__.py
+++ b/src/custom_parser/__init__.py
@@ -35,6 +35,18 @@ def check_env_vars():
             print(key + " not set")
         exit(1)
 
+def signal_enabled(var_value):
+    """Decide whether an OTel signal is enabled from its standard exporter selection var.
+
+    Follows the OpenTelemetry spec for OTEL_{TRACES,METRICS,LOGS}_EXPORTER: a signal is
+    disabled only when the var is set to "none" (case-insensitive, trimmed). Every other
+    value -- unset, empty, "otlp", or anything else -- leaves the signal enabled, which
+    keeps the default behavior (all three signals on) unchanged.
+    """
+    if var_value is None:
+        return True
+    return var_value.strip().lower() != "none"
+
 def parse_attributes(obj,att_to_drop,otype):
     obj_atts = {}
     attributes_to_drop = []

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,5 +1,5 @@
 from ghapi.all import GhApi
-from custom_parser import do_time,do_fastcore_decode,parse_attributes,check_env_vars
+from custom_parser import do_time,do_fastcore_decode,parse_attributes,check_env_vars,signal_enabled
 import json
 import logging
 import os
@@ -37,9 +37,19 @@ GITHUB_REPOSITORY_OWNER=os.getenv('GITHUB_REPOSITORY_OWNER')
 
 EXPORTER_JOB_NAME=os.getenv('GITHUB_JOB').lower()
 
+# Per-signal selection via the standard OTel SDK exporter vars.
+# A signal is disabled only when its var is set to "none" (case-insensitive, trimmed);
+# unset/empty/"otlp"/anything else leaves it enabled, so the default is all three on.
+TRACES_ENABLED = signal_enabled(os.getenv('OTEL_TRACES_EXPORTER'))
+METRICS_ENABLED = signal_enabled(os.getenv('OTEL_METRICS_EXPORTER'))
+LOGS_ENABLED = signal_enabled(os.getenv('OTEL_LOGS_EXPORTER'))
+
 # Check if debug is set
 if "GITHUB_DEBUG" in os.environ and os.getenv('GITHUB_DEBUG').lower() == "true":
     print("Running on DEBUG mode")
+    print(f"Signal selection -> traces: {'enabled' if TRACES_ENABLED else 'disabled'}, "
+          f"metrics: {'enabled' if METRICS_ENABLED else 'disabled'}, "
+          f"logs: {'enabled' if LOGS_ENABLED else 'disabled'}")
     import http.client as http_client
     http_client.HTTPConnection.debuglevel = 1
     LoggingInstrumentor().instrument(set_logging_format=True,log_level=logging.DEBUG)
@@ -95,8 +105,8 @@ if GITHUB_CUSTOM_ATTS != "":
 
 # Set workflow level tracer. meter and logger
 global_resource = Resource(attributes=global_attributes)
-tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "tracer", OTLP_PROTOCOL)
-meter = otel_meter(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "meter", OTLP_PROTOCOL)
+tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "tracer", OTLP_PROTOCOL, enabled=TRACES_ENABLED)
+meter = otel_meter(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "meter", OTLP_PROTOCOL, enabled=METRICS_ENABLED)
 
 # Ensure we don't export data for the OTLP_GitHubAction-Exporter job
 workflow_run = json.loads(get_workflow_run_jobs_by_run_id)
@@ -185,12 +195,12 @@ for job in job_lst:
                         pass
                 resource_log = Resource(attributes=resource_attributes)
                 
-                step_tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, resource_log, "step_tracer", OTLP_PROTOCOL)
+                step_tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, resource_log, "step_tracer", OTLP_PROTOCOL, enabled=TRACES_ENABLED)
                 
                 resource_attributes[cicd_semconv.CICD_PIPELINE_TASK_NAME.replace("pipeline.task", "pipeline.task.step")] = step['name']
                 resource_attributes.update(create_otel_attributes(parse_attributes(step,"","step"),GITHUB_REPOSITORY_NAME))
                 resource_log = Resource(attributes=resource_attributes)
-                job_logger = otel_logger(OTEL_EXPORTER_OTLP_ENDPOINT,headers,resource_log, "job_logger", OTLP_PROTOCOL)
+                job_logger = otel_logger(OTEL_EXPORTER_OTLP_ENDPOINT,headers,resource_log, "job_logger", OTLP_PROTOCOL, enabled=LOGS_ENABLED)
 
                 if step['conclusion'] == 'skipped' or step['conclusion'] == 'cancelled':
                     if index >= 1:  

--- a/src/otel/__init__.py
+++ b/src/otel/__init__.py
@@ -70,10 +70,15 @@ def create_otel_attributes(atts, GITHUB_SERVICE_NAME):
             attributes[att]=atts[att]
     return attributes
 
-def otel_logger(endpoint, headers, resource, name, export_protocol):
-    exporter = getLogExporter(endpoint=f"{endpoint}v1/logs",headers=headers, protocol=export_protocol )
+def otel_logger(endpoint, headers, resource, name, export_protocol, enabled=True):
     logger = logging.getLogger(str(name))
     logger.handlers.clear()
+    if not enabled:
+        # No OTLP LoggingHandler: log records emitted on this logger are dropped.
+        # The NullHandler keeps disabled lines from falling through to the root logger/stdout.
+        logger.addHandler(logging.NullHandler())
+        return logger
+    exporter = getLogExporter(endpoint=f"{endpoint}v1/logs",headers=headers, protocol=export_protocol )
     logger_provider = LoggerProvider(resource=resource)
     logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
     handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
@@ -81,7 +86,11 @@ def otel_logger(endpoint, headers, resource, name, export_protocol):
     return logger
 
 
-def otel_tracer(endpoint, headers, resource, tracer, export_protocol):
+def otel_tracer(endpoint, headers, resource, tracer, export_protocol, enabled=True):
+    if not enabled:
+        # No SDK provider installed: returns the API default no-op tracer.
+        # start_span/set_status/end on its spans are harmless no-ops.
+        return trace.get_tracer(__name__)
     processor = BatchSpanProcessor(getSpanExporter(endpoint=f"{endpoint}v1/traces",headers=headers, protocol=export_protocol ))
     tracer = TracerProvider(resource=resource)
     tracer.add_span_processor(processor)
@@ -89,7 +98,11 @@ def otel_tracer(endpoint, headers, resource, tracer, export_protocol):
 
     return tracer
 
-def otel_meter(endpoint, headers, resource, meter, export_protocol):
+def otel_meter(endpoint, headers, resource, meter, export_protocol, enabled=True):
+    if not enabled:
+        # No SDK provider installed: returns the API default no-op meter.
+        # create_counter(...).add(...) on it is a harmless no-op.
+        return metrics.get_meter(__name__)
     reader = PeriodicExportingMetricReader(getMetricExporter(endpoint=f"{endpoint}v1/metrics",headers=headers, protocol=export_protocol ))
     provider = MeterProvider(resource=resource, metric_readers=[reader])
     meter = metrics.get_meter(__name__,meter_provider=provider)


### PR DESCRIPTION
Honor the standard OpenTelemetry SDK exporter selection vars so individual signals can be turned off independently:
- `OTEL_TRACES_EXPORTER=none`
- `OTEL_METRICS_EXPORTER=none`
- `OTEL_LOGS_EXPORTER=none`

A signal is disabled only when its var is set to "none" (case-insensitive, trimmed), per the OTel spec. Any other value -- unset, empty, "otlp", or anything else -- leaves the signal enabled.

Backwards compatibility is preserved because the default behavior (all three signals on) is unchanged.

Log-line parsing is left ungated on logs being enabled: span error status is still derived from "##[error]" lines, so traces-only mode keeps accurate span status while emitting no log records.