### PR TITLE
fix: quote github.repository in example GITHUB_CUSTOM_ATTS

### DIFF
--- a/OTLP-GitHubAction-Exporter.yaml.coralogix.example
+++ b/OTLP-GitHubAction-Exporter.yaml.coralogix.example
@@ -20,7 +20,7 @@ env:
   OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer ${{ secrets.CORALOGIX_API_KEY }}
   GITHUB_CUSTOM_ATTS: '{"cx.application.name":"github", "cx.subsystem.name":"actions"}'
   # You can override service.name or make subsystem dynamic
-  # GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":${{ github.repository }}}'
+  # GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":"${{ github.repository }}"}'
 
 jobs:
   Coralogix-GitHubAction-Exporter:


### PR DESCRIPTION
## What

The commented-out alternative form of `GITHUB_CUSTOM_ATTS` in `OTLP-GitHubAction-Exporter.yaml.coralogix.example` (line 23) has `${{ github.repository }}` unquoted inside a JSON string value:

```yaml
# GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":${{ github.repository }}}'
```

After GitHub Actions expression substitution, this renders as e.g.:

```
{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":owner/repo}
```

which is **invalid JSON** — the value is an unquoted bareword containing `/`. Users who copy this line as-is to make their subsystem dynamic end up with a malformed `GITHUB_CUSTOM_ATTS` env that the exporter can't parse.

## Fix

Wrap the expression in double quotes so the JSON is valid after substitution:

```yaml
# GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":"${{ github.repository }}"}'
```

## Note

The same broken form appears in the Coralogix docs page at https://coralogix.com/docs/integrations/ci/cd/github-actions/ (in the primary example, not commented out). Filing this PR against the upstream example first, since the docs page links here as the canonical source. Happy to also flag the docs page through your support channel if helpful.