### PR TITLE
fix: set GhApi to Sync usage.

### DIFF
--- a/src/exporter.py
+++ b/src/exporter.py
@@ -64,7 +64,7 @@ if OTEL_EXPORTER_OTLP_HEADERS:
             headers[key] = value
 
 # Github API client
-api = GhApi(owner=GITHUB_REPOSITORY_OWNER, repo=GITHUB_REPOSITORY_NAME.split('/')[1], token=str(ACTION_TOKEN))
+api = GhApi(owner=GITHUB_REPOSITORY_OWNER, repo=GITHUB_REPOSITORY_NAME.split('/')[1], token=str(ACTION_TOKEN), sync=True)
 
 # Github API calls
 get_workflow_run_by_run_id = do_fastcore_decode(api.actions.get_workflow_run(WORKFLOW_RUN_ID))


### PR DESCRIPTION

## Description

`ghapi` recently released version 2.0, which makes the library async by default. Because of this breaking change, the action currently fails with the following error whenever it runs:
```
TypeError: Object of type coroutine is not JSON serializable
sys:1: RuntimeWarning: coroutine 'OpFunc.call' was never awaited
```

According to the [ghapi documentation](https://ghapi.fast.ai/), we can pass `sync=True` to preserve the sync behavior from v1. 


## Changes

* Initialized `GhApi(sync=True)` to fix the coroutine error and maintain compatibility with our existing synchronous codebase.