### PR TITLE
RDP-22773: pin ghapi==1.1.0 and fastcore==1.14.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,10 @@ opentelemetry.exporter.otlp.proto.grpc
 opentelemetry.exporter.otlp.proto.http
 opentelemetry.instrumentation.logging
 pyrfc3339
-ghapi
+# Pinned: ghapi 2.0.0 made the client async (calls return coroutines),
+# breaking json.dumps() in the exporter. fastcore is ghapi's transitive dep,
+# pinned to the last-known-good pair. See RDP-22773.
+ghapi==1.1.0
+fastcore==1.14.3
 requests
 python-dateutil


### PR DESCRIPTION
ghapi 2.0.0 made the client async so previously-sync calls like api.actions.get_workflow_run() now return a coroutine, breaking json.dumps() in the exporter (TypeError: Object of type coroutine is not JSON serializable). The Docker image rebuilds requirements.txt on every run, so the unpinned dep drifted to a breaking major with no code change. Pin to the last-known-good versions to restore CI and make builds deterministic.