### PR TITLE
constrain ghapi to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Changelog
 
-## 3.3.0 (2025-08-27)
+## 3.3.2 (2026-07-09)
 
-* [feat] Publish new action to be used by Coralogix integration
+* [fix] Pin ghapi below 2.0.0 to avoid breaking async API change
 
 ## 3.3.1 (2026-03-04)
 
 * [fix] Handle slashes in the Action step's name
+
+## 3.3.0 (2025-08-27)
+
+* [feat] Publish new action to be used by Coralogix integration

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ opentelemetry.exporter.otlp.proto.grpc
 opentelemetry.exporter.otlp.proto.http
 opentelemetry.instrumentation.logging
 pyrfc3339
-ghapi
+ghapi>=1.1.0,<2.0.0
 requests
 python-dateutil


### PR DESCRIPTION
Pin ghapi below 2.0.0 to avoid breaking async API change