### PR TITLE
release v3.4.0

### DIFF
--- a/.github/workflows/create-release-PR.yml
+++ b/.github/workflows/create-release-PR.yml
@@ -13,12 +13,12 @@ jobs:
   create-release-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           release-type: simple
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: tag major and minor versions
         if: ${{ steps.release.outputs.release_created }}
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## 3.4.0 (2026-07-09)
 
-* [feat] Upgrade to ghapi 2.x using sync client mode
+* [feat] Upgrade to ghapi 2.x using sync client mode ([#9](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/9), thanks @g-sponda)
+* [feat] Allow disabling traces, metrics, or logs independently via `OTEL_*_EXPORTER=none` ([#6](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/6), thanks @dzaman)
+* [feat] Emit histogram metrics for workflow, job, and step duration ([#8](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/8), thanks @julesverned)
+* [fix] Quote `github.repository` in example `GITHUB_CUSTOM_ATTS` JSON ([#7](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/7), thanks @julesverned)
 
 ## 3.3.2 (2026-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * [feat] Allow disabling traces, metrics, or logs independently via `OTEL_*_EXPORTER=none` ([#6](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/6), thanks @dzaman)
 * [feat] Emit histogram metrics for workflow, job, and step duration ([#8](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/8), thanks @julesverned)
 * [fix] Quote `github.repository` in example `GITHUB_CUSTOM_ATTS` JSON ([#7](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/7), thanks @julesverned)
+* [fix] Paginate workflow jobs API calls so runs with more than 30 jobs export completely (thanks @gangadhar-res, [StephenGoodall#38](https://github.com/StephenGoodall/OTLP-GitHubAction-Exporter/pull/38))
+* [chore] Bump `opentelemetry-sdk` to `>=1.43.0`
 
 ## 3.3.2 (2026-07-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.4.0 (2026-07-09)
+
+* [feat] Upgrade to ghapi 2.x using sync client mode
+
 ## 3.3.2 (2026-07-09)
 
 * [fix] Pin ghapi below 2.0.0 to avoid breaking async API change

--- a/OTLP-GitHubAction-Exporter.yaml.coralogix.example
+++ b/OTLP-GitHubAction-Exporter.yaml.coralogix.example
@@ -18,9 +18,13 @@ env:
   # Change to your region's endpoint (https://coralogix.com/docs/integrations/coralogix-endpoints/)
   OTEL_EXPORTER_OTLP_ENDPOINT: https://ingress.eu2.coralogix.com/ 
   OTEL_EXPORTER_OTLP_HEADERS: Authorization=Bearer ${{ secrets.CORALOGIX_API_KEY }}
+  # Per-signal selection (OpenTelemetry standard vars). Set to "none" to disable a signal
+  # OTEL_TRACES_EXPORTER: none
+  # OTEL_METRICS_EXPORTER: none
+  # OTEL_LOGS_EXPORTER: none
   GITHUB_CUSTOM_ATTS: '{"cx.application.name":"github", "cx.subsystem.name":"actions"}'
   # You can override service.name or make subsystem dynamic
-  # GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":${{ github.repository }}}'
+  # GITHUB_CUSTOM_ATTS: '{"service.name":"ghapp", "cx.application.name":"ghactions", "cx.subsystem.name":"${{ github.repository }}"}'
 
 jobs:
   Coralogix-GitHubAction-Exporter:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ This means it will run whenever any of your other workflows complete - which mea
 
 `GITHUB_DEBUG` - see [Troubleshooting](#Troubleshooting)
 
+`OTEL_TRACES_EXPORTER` / `OTEL_METRICS_EXPORTER` / `OTEL_LOGS_EXPORTER` - Per-signal on/off switches following the [OpenTelemetry SDK exporter spec](https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/). A signal is **disabled** only when its variable is set to `none` (case-insensitive). Any other value — unset, empty, `otlp`, etc. — leaves the signal **enabled**. By default all three are unset, so all signals are exported (unchanged behavior). When a signal is disabled, no exporter is created and no data is sent for it. Note: only `none` is special-cased to disable; any other value is treated as OTLP (other exporter types such as `console` are not supported).
+
+#### Example: traces only
+
+To export spans but no metrics or logs:
+
+```
+env:
+  OTEL_METRICS_EXPORTER: none
+  OTEL_LOGS_EXPORTER: none
+```
+
 ## Examples
 
 Traces are viewable in the Tracing console within Coralogix. The service name will be your repository name:
@@ -67,11 +79,17 @@ Each trace can be opened to show the steps in context:
 Logs will be available in the Logs console with few attributes that you can use as panel columns. Also, you have an option to use them for filtering.
 ![Logs](images/Logs.png)
 
-Metrics will be available in the Metrics console. There are 3 metrics available:
+Metrics will be available in the Metrics console. Counter metrics available:
 
 * `github_workflow_failed_job_count_total`
 * `github_workflow_overall_job_count_total`
-* `github_workflow_successful_job_count_total`.
+* `github_workflow_successful_job_count_total`
+
+Histogram metrics for duration analysis (p95, rate, etc.):
+
+* `github_workflow_run_duration_seconds_{count,sum,bucket}`
+* `github_workflow_job_duration_seconds_{count,sum,bucket}`
+* `github_workflow_step_duration_seconds_{count,sum,bucket}`
 
 All those metrics contain the service name (i.e. repository name) label.
 ![Metrics](images/Metrics.png)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 opentelemetry.api
-opentelemetry.sdk>=1.27.0
+opentelemetry.sdk>=1.43.0
 opentelemetry.exporter.otlp.proto.grpc
 opentelemetry.exporter.otlp.proto.http
 opentelemetry.instrumentation.logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@ opentelemetry.exporter.otlp.proto.grpc
 opentelemetry.exporter.otlp.proto.http
 opentelemetry.instrumentation.logging
 pyrfc3339
-ghapi>=1.1.0,<2.0.0
+ghapi>=2.0.0,<3.0.0
 requests
 python-dateutil

--- a/src/custom_parser/__init__.py
+++ b/src/custom_parser/__init__.py
@@ -35,6 +35,18 @@ def check_env_vars():
             print(key + " not set")
         exit(1)
 
+def signal_enabled(var_value):
+    """Decide whether an OTel signal is enabled from its standard exporter selection var.
+
+    Follows the OpenTelemetry spec for OTEL_{TRACES,METRICS,LOGS}_EXPORTER: a signal is
+    disabled only when the var is set to "none" (case-insensitive, trimmed). Every other
+    value -- unset, empty, "otlp", or anything else -- leaves the signal enabled, which
+    keeps the default behavior (all three signals on) unchanged.
+    """
+    if var_value is None:
+        return True
+    return var_value.strip().lower() != "none"
+
 def parse_attributes(obj,att_to_drop,otype):
     obj_atts = {}
     attributes_to_drop = []

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -64,7 +64,7 @@ if OTEL_EXPORTER_OTLP_HEADERS:
             headers[key] = value
 
 # Github API client
-api = GhApi(owner=GITHUB_REPOSITORY_OWNER, repo=GITHUB_REPOSITORY_NAME.split('/')[1], token=str(ACTION_TOKEN))
+api = GhApi(owner=GITHUB_REPOSITORY_OWNER, repo=GITHUB_REPOSITORY_NAME.split('/')[1], token=str(ACTION_TOKEN), sync=True)
 
 # Github API calls
 get_workflow_run_by_run_id = do_fastcore_decode(api.actions.get_workflow_run(WORKFLOW_RUN_ID))

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -78,7 +78,26 @@ api = GhApi(owner=GITHUB_REPOSITORY_OWNER, repo=GITHUB_REPOSITORY_NAME.split('/'
 
 # Github API calls
 get_workflow_run_by_run_id = do_fastcore_decode(api.actions.get_workflow_run(WORKFLOW_RUN_ID))
-get_workflow_run_jobs_by_run_id = do_fastcore_decode(api.actions.list_jobs_for_workflow_run(WORKFLOW_RUN_ID))
+
+# Page through all jobs. GitHub paginates the list-jobs endpoint at 30 per
+# page by default, so any workflow with more than 30 jobs would silently
+# drop everything past the first page (including failures and post-deploy
+# validation jobs). per_page=100 is the GitHub maximum.
+all_jobs = []
+last_page = None
+page_num = 1
+while True:
+    page_resp = do_fastcore_decode(api.actions.list_jobs_for_workflow_run(WORKFLOW_RUN_ID, per_page=100, page=page_num))
+    last_page = json.loads(page_resp)
+    page_jobs = last_page.get("jobs", [])
+    all_jobs.extend(page_jobs)
+    if len(page_jobs) < 100:
+        break
+    page_num += 1
+get_workflow_run_jobs_by_run_id = json.dumps({
+    "jobs": all_jobs,
+    "total_count": last_page.get("total_count", len(all_jobs)) if last_page else 0,
+})
 
 # Set OTEL resources
 global_attributes={

--- a/src/exporter.py
+++ b/src/exporter.py
@@ -1,5 +1,5 @@
 from ghapi.all import GhApi
-from custom_parser import do_time,do_fastcore_decode,parse_attributes,check_env_vars
+from custom_parser import do_time,do_fastcore_decode,parse_attributes,check_env_vars,signal_enabled
 import json
 import logging
 import os
@@ -37,9 +37,19 @@ GITHUB_REPOSITORY_OWNER=os.getenv('GITHUB_REPOSITORY_OWNER')
 
 EXPORTER_JOB_NAME=os.getenv('GITHUB_JOB').lower()
 
+# Per-signal selection via the standard OTel SDK exporter vars.
+# A signal is disabled only when its var is set to "none" (case-insensitive, trimmed);
+# unset/empty/"otlp"/anything else leaves it enabled, so the default is all three on.
+TRACES_ENABLED = signal_enabled(os.getenv('OTEL_TRACES_EXPORTER'))
+METRICS_ENABLED = signal_enabled(os.getenv('OTEL_METRICS_EXPORTER'))
+LOGS_ENABLED = signal_enabled(os.getenv('OTEL_LOGS_EXPORTER'))
+
 # Check if debug is set
 if "GITHUB_DEBUG" in os.environ and os.getenv('GITHUB_DEBUG').lower() == "true":
     print("Running on DEBUG mode")
+    print(f"Signal selection -> traces: {'enabled' if TRACES_ENABLED else 'disabled'}, "
+          f"metrics: {'enabled' if METRICS_ENABLED else 'disabled'}, "
+          f"logs: {'enabled' if LOGS_ENABLED else 'disabled'}")
     import http.client as http_client
     http_client.HTTPConnection.debuglevel = 1
     LoggingInstrumentor().instrument(set_logging_format=True,log_level=logging.DEBUG)
@@ -95,8 +105,8 @@ if GITHUB_CUSTOM_ATTS != "":
 
 # Set workflow level tracer. meter and logger
 global_resource = Resource(attributes=global_attributes)
-tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "tracer", OTLP_PROTOCOL)
-meter = otel_meter(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "meter", OTLP_PROTOCOL)
+tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "tracer", OTLP_PROTOCOL, enabled=TRACES_ENABLED)
+meter = otel_meter(OTEL_EXPORTER_OTLP_ENDPOINT, headers, global_resource, "meter", OTLP_PROTOCOL, enabled=METRICS_ENABLED)
 
 # Ensure we don't export data for the OTLP_GitHubAction-Exporter job
 workflow_run = json.loads(get_workflow_run_jobs_by_run_id)
@@ -114,6 +124,22 @@ job_counter.add(len(job_lst))
 
 successful_job_counter = meter.create_counter(name="github.workflow.successful.job_count", description="Number of Successful Jobs in the Workflow Run")
 failed_job_counter = meter.create_counter(name="github.workflow.failed.job_count", description="Number of Failed Jobs in the Workflow Run")
+
+workflow_run_duration_histogram = meter.create_histogram(
+    name="github.workflow.run.duration",
+    unit="s",
+    description="Duration of a GitHub Actions workflow run, in seconds."
+)
+job_duration_histogram = meter.create_histogram(
+    name="github.workflow.job.duration",
+    unit="s",
+    description="Duration of a GitHub Actions workflow job, in seconds."
+)
+step_duration_histogram = meter.create_histogram(
+    name="github.workflow.step.duration",
+    unit="s",
+    description="Duration of a GitHub Actions workflow step, in seconds."
+)
 
 
 # Trace parent
@@ -185,12 +211,12 @@ for job in job_lst:
                         pass
                 resource_log = Resource(attributes=resource_attributes)
                 
-                step_tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, resource_log, "step_tracer", OTLP_PROTOCOL)
+                step_tracer = otel_tracer(OTEL_EXPORTER_OTLP_ENDPOINT, headers, resource_log, "step_tracer", OTLP_PROTOCOL, enabled=TRACES_ENABLED)
                 
                 resource_attributes[cicd_semconv.CICD_PIPELINE_TASK_NAME.replace("pipeline.task", "pipeline.task.step")] = step['name']
                 resource_attributes.update(create_otel_attributes(parse_attributes(step,"","step"),GITHUB_REPOSITORY_NAME))
                 resource_log = Resource(attributes=resource_attributes)
-                job_logger = otel_logger(OTEL_EXPORTER_OTLP_ENDPOINT,headers,resource_log, "job_logger", OTLP_PROTOCOL)
+                job_logger = otel_logger(OTEL_EXPORTER_OTLP_ENDPOINT,headers,resource_log, "job_logger", OTLP_PROTOCOL, enabled=LOGS_ENABLED)
 
                 if step['conclusion'] == 'skipped' or step['conclusion'] == 'cancelled':
                     if index >= 1:  
@@ -268,16 +294,61 @@ for job in job_lst:
                     step_completed_at=step['completed_at']
                                     
                 child_1.end(end_time=do_time(step_completed_at))
+                try:
+                    step_duration_seconds = (do_time(step_completed_at) - do_time(step_started_at)) / 1e9
+                    if step_duration_seconds >= 0:
+                        step_duration_histogram.record(
+                            step_duration_seconds,
+                            attributes={
+                                "repo": GITHUB_REPOSITORY_NAME,
+                                "workflow": str(workflow_run_atts.get("path") or workflow_run_atts.get("name") or WORKFLOW_RUN_NAME),
+                                "job": str(job["name"]),
+                                "step": str(step["name"]),
+                                "conclusion": str(step.get("conclusion") or ""),
+                                "runner_group": str(job.get("runner_group_name") or ""),
+                            },
+                        )
+                except Exception as e:
+                    print("Failed to record step duration histogram ->", step["name"], "<- error", e)
                 print("Finished processing step ->",step['name'],"from job",job['name'])
             except Exception as e:
                 print("Unable to process step ->",step['name'],"<- due to error",e)
                 
         child_0.end(end_time=do_time(job['completed_at']))
+        try:
+            job_duration_seconds = (do_time(job["completed_at"]) - do_time(job["started_at"])) / 1e9
+            if job_duration_seconds >= 0:
+                job_duration_histogram.record(
+                    job_duration_seconds,
+                    attributes={
+                        "repo": GITHUB_REPOSITORY_NAME,
+                        "workflow": str(workflow_run_atts.get("path") or workflow_run_atts.get("name") or WORKFLOW_RUN_NAME),
+                        "job": str(job["name"]),
+                        "conclusion": str(job.get("conclusion") or ""),
+                        "runner_group": str(job.get("runner_group_name") or ""),
+                    },
+                )
+        except Exception as e:
+            print("Failed to record job duration histogram ->", job["name"], "<- error", e)
         print("Finished processing job ->",job['name'])
     except Exception as e:
         print("Unable to process job ->",job['name'],"<- due to error",e)
 
 workflow_run_finish_time=do_time(workflow_run_atts['updated_at'])
 p_parent.end(end_time=workflow_run_finish_time)
+try:
+    workflow_run_duration_seconds = (workflow_run_finish_time - do_time(workflow_run_atts["run_started_at"])) / 1e9
+    if workflow_run_duration_seconds >= 0:
+        workflow_run_duration_histogram.record(
+            workflow_run_duration_seconds,
+            attributes={
+                "repo": GITHUB_REPOSITORY_NAME,
+                "workflow": str(workflow_run_atts.get("path") or workflow_run_atts.get("name") or WORKFLOW_RUN_NAME),
+                "conclusion": str(workflow_run_atts.get("conclusion") or ""),
+                "event": str(workflow_run_atts.get("event") or ""),
+            },
+        )
+except Exception as e:
+    print("Failed to record workflow run duration histogram ->", WORKFLOW_RUN_NAME, "<- error", e)
 print("Finished processing Workflow ->",WORKFLOW_RUN_NAME,"run id ->",WORKFLOW_RUN_ID)
 print("All data exported to OTLP")

--- a/src/otel/__init__.py
+++ b/src/otel/__init__.py
@@ -70,10 +70,15 @@ def create_otel_attributes(atts, GITHUB_SERVICE_NAME):
             attributes[att]=atts[att]
     return attributes
 
-def otel_logger(endpoint, headers, resource, name, export_protocol):
-    exporter = getLogExporter(endpoint=f"{endpoint}v1/logs",headers=headers, protocol=export_protocol )
+def otel_logger(endpoint, headers, resource, name, export_protocol, enabled=True):
     logger = logging.getLogger(str(name))
     logger.handlers.clear()
+    if not enabled:
+        # No OTLP LoggingHandler: log records emitted on this logger are dropped.
+        # The NullHandler keeps disabled lines from falling through to the root logger/stdout.
+        logger.addHandler(logging.NullHandler())
+        return logger
+    exporter = getLogExporter(endpoint=f"{endpoint}v1/logs",headers=headers, protocol=export_protocol )
     logger_provider = LoggerProvider(resource=resource)
     logger_provider.add_log_record_processor(BatchLogRecordProcessor(exporter))
     handler = LoggingHandler(level=logging.NOTSET, logger_provider=logger_provider)
@@ -81,7 +86,11 @@ def otel_logger(endpoint, headers, resource, name, export_protocol):
     return logger
 
 
-def otel_tracer(endpoint, headers, resource, tracer, export_protocol):
+def otel_tracer(endpoint, headers, resource, tracer, export_protocol, enabled=True):
+    if not enabled:
+        # No SDK provider installed: returns the API default no-op tracer.
+        # start_span/set_status/end on its spans are harmless no-ops.
+        return trace.get_tracer(__name__)
     processor = BatchSpanProcessor(getSpanExporter(endpoint=f"{endpoint}v1/traces",headers=headers, protocol=export_protocol ))
     tracer = TracerProvider(resource=resource)
     tracer.add_span_processor(processor)
@@ -89,7 +98,11 @@ def otel_tracer(endpoint, headers, resource, tracer, export_protocol):
 
     return tracer
 
-def otel_meter(endpoint, headers, resource, meter, export_protocol):
+def otel_meter(endpoint, headers, resource, meter, export_protocol, enabled=True):
+    if not enabled:
+        # No SDK provider installed: returns the API default no-op meter.
+        # create_counter(...).add(...) on it is a harmless no-op.
+        return metrics.get_meter(__name__)
     reader = PeriodicExportingMetricReader(getMetricExporter(endpoint=f"{endpoint}v1/metrics",headers=headers, protocol=export_protocol ))
     provider = MeterProvider(resource=resource, metric_readers=[reader])
     meter = metrics.get_meter(__name__,meter_provider=provider)


### PR DESCRIPTION
## 3.4.0 (2026-07-09)

* [feat] Upgrade to ghapi 2.x using sync client mode ([#9](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/9), thanks @g-sponda)
* [feat] Allow disabling traces, metrics, or logs independently via `OTEL_*_EXPORTER=none` ([#6](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/6), thanks @dzaman)
* [feat] Emit histogram metrics for workflow, job, and step duration ([#8](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/8), thanks @julesverned)
* [fix] Quote `github.repository` in example `GITHUB_CUSTOM_ATTS` JSON ([#7](https://github.com/coralogix/OTLP-GitHubAction-Exporter/pull/7), thanks @julesverned)
* [fix] Paginate workflow jobs API calls so runs with more than 30 jobs export completely (thanks @gangadhar-res, [StephenGoodall#38](https://github.com/StephenGoodall/OTLP-GitHubAction-Exporter/pull/38))
* [chore] Bump `opentelemetry-sdk` to `>=1.43.0`